### PR TITLE
Don't download nix with https

### DIFF
--- a/installNix.sh
+++ b/installNix.sh
@@ -27,7 +27,7 @@ case "$(uname -s).$(uname -m)" in
     *) oops "sorry, there is no binary distribution of Nix for your platform";;
 esac
 
-url="https://nixos.org/releases/nix/nix-1.10/nix-1.10-$system.tar.bz2"
+url="http://nixos.org/releases/nix/nix-1.10/nix-1.10-$system.tar.bz2"
 
 require_util curl "download the binary tarball"
 require_util bzcat "decompress the binary tarball"


### PR DESCRIPTION
On my system when I run try-reflex it fails with this error

    SSL: can't load CA certificate file /Users/mightybyte/.nix-profile/etc/ca-bundle.crt

Not using https seems to solve this problem.