### PR TITLE
Workaround for ghcjs hardcoding to linux

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -43,6 +43,7 @@ let iosSupport = system == "x86_64-darwin";
           inherit (self) lib;
           haskellLib = self.haskell.lib;
           inherit
+            system
             useFastWeak useReflexOptimizer enableLibraryProfiling enableTraceReflexEvents
             useTextJSString enableExposeAllUnfoldings
             haskellOverlays;

--- a/haskell-overlays/default.nix
+++ b/haskell-overlays/default.nix
@@ -1,4 +1,5 @@
-{ lib
+{ system
+, lib
 , haskellLib
 , nixpkgs
 , useFastWeak, useReflexOptimizer, enableLibraryProfiling, enableTraceReflexEvents
@@ -112,7 +113,7 @@ rec {
 
   # Just for GHCJS
   ghcjs = import ./ghcjs.nix {
-    inherit lib haskellLib nixpkgs fetchgit fetchFromGitHub useReflexOptimizer;
+    inherit system lib haskellLib nixpkgs fetchgit fetchFromGitHub useReflexOptimizer;
   };
   ghcjs-fast-weak = import ./ghcjs-fast-weak {
    inherit lib;

--- a/haskell-overlays/ghcjs.nix
+++ b/haskell-overlays/ghcjs.nix
@@ -4,6 +4,8 @@ with haskellLib;
 
 self: super:
 
+# Workaround for https://github.com/ghcjs/ghcjs/issues/674
+# 'os (osx)' will always evaluate to 'false'
 let dontHardcodeLinux = package: cabalFile:
   if ! self.ghc.isGhcjs then package
   else nixpkgs.haskell.lib.overrideCabal package (drv: {


### PR DESCRIPTION
Due to https://github.com/ghcjs/ghcjs/issues/674
Upstreaming @vaibhavsagar's fix since we both ran into this on different projects.

Test case: https://github.com/obsidiansystems/obelisk/compare/develop...alexfmpe:ae-error-foundation