### PR TITLE
Fix splice loading for non-default version in package set

### DIFF
--- a/haskell-overlays/splices-load-save/load-splices.nix
+++ b/haskell-overlays/splices-load-save/load-splices.nix
@@ -3,10 +3,10 @@
 self: super:
 
 let splicedPkg = drv:
-      if builtins.hasAttr drv.pname self.buildHaskellPackages
-      then builtins.getAttr drv.pname self.buildHaskellPackages
-      else if builtins.hasAttr (attrName drv) self.buildHaskellPackages
+      if builtins.hasAttr (attrName drv) self.buildHaskellPackages
       then builtins.getAttr (attrName drv) self.buildHaskellPackages
+      else if builtins.hasAttr drv.pname self.buildHaskellPackages
+      then builtins.getAttr drv.pname self.buildHaskellPackages
       else throw "no spliced pkg for: ${drv.name}";
 
     hasSplicedPkg = drv:


### PR DESCRIPTION
Checking for `pname` match first means when using the non-default versions we'll actually load the default ones. I noticed this because I was overriding Cabal to Cabal-3.6.3.0 to get around a linker failure happening on older Cabal, and then hit this error message
```
error: splicedDrv == null for drv = Cabal
```
Since `haskellPackages.Cabal` is `null` due to it being a compiler-bundled package, and us selecting it since `Cabal_3_6_3_0.pname == "Cabal"`. As for other packages, they were just silently switched. I noticed at least `Some-1.0.4` getting rebuilt