### PR TITLE
Forward compatibility with iproute deprecation

### DIFF
--- a/haskell-overlays/reflex-packages/default.nix
+++ b/haskell-overlays/reflex-packages/default.nix
@@ -105,7 +105,7 @@ in
         nixpkgs_oldChromium.chromium
         which
       ] ++ lib.optionals (!noGcTest) [
-        nixpkgs.iproute
+        nixpkgs.iproute2
       ];
     } // lib.optionalAttrs (!noGcTest) {
       # The headless browser run as part of gc tests would hang/crash without this


### PR DESCRIPTION
```
$ nix-build -A nixpkgs.iproute2
/nix/store/03q9fjs925aznfmlm476hpkdjbcvky6z-iproute2-5.19.0

$ nix-build -A nixpkgs.iproute
/nix/store/03q9fjs925aznfmlm476hpkdjbcvky6z-iproute2-5.19.0
```