### PR TITLE
Use buildIcons.nix

### DIFF
--- a/android/AndroidManifest.xml.nix
+++ b/android/AndroidManifest.xml.nix
@@ -18,7 +18,7 @@ in ''
       android:versionCode="${version.code}"
       android:versionName="${version.name}">
     <application android:label="@string/app_name"
-                 android:icon="${iconPath}"
+                 android:icon="@drawable/ic_launcher"
                  android:allowBackup="${boolStr allowBackup}"
                  android:fullBackupContent="${boolStr fullBackupContent}"
                  android:hardwareAccelerated="true"

--- a/android/default.nix
+++ b/android/default.nix
@@ -31,7 +31,7 @@ in rec {
 
   defaultResources = ./res;
   defaultAssets = ./assets;
-  defaultIconPath = "@drawable/ic_launcher";
+  defaultIconPath = ./res/drawable-xhdpi/ic_launcher.png;
 
   buildIcons = nixpkgs.callPackage ./buildIcons.nix {};
 

--- a/android/impl.nix
+++ b/android/impl.nix
@@ -139,7 +139,7 @@ in {
             }
         '') abiVersions) + ''
           rsync -r --chmod=+w "${assets}"/ "$out/assets/"
-          rsync -r --chmod=+w "${resources}"/ "$out/res/"
+          rsync -r --chmod=+w "${nixpkgs.callPackage ./buildIcons.nix {} { src = iconPath; }}"/ "$out/res/"
           [ -d "$out/assets" ]
           [ -d "$out/res" ]
         '');


### PR DESCRIPTION
Currently buildIcons.nix is unused so overriding iconPath did nothing.

This simply uses the iconPath as the src arg for the existing buildIcons.nix to generate the `res/drawable-{screensize}/` folders 