### PR TITLE
Bump android target sdk version to 35

### DIFF
--- a/android/build.gradle.nix
+++ b/android/build.gradle.nix
@@ -69,7 +69,7 @@ android {
     defaultConfig {
         applicationId "${applicationId}"
         minSdkVersion 21
-        targetSdkVersion 34
+        targetSdkVersion 35
         versionCode ${version.code}
         versionName "${version.name}"
         multiDexEnabled false

--- a/android/build.gradle.nix
+++ b/android/build.gradle.nix
@@ -45,7 +45,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 30
-    buildToolsVersion '30.0.2'
 
     lintOptions {
       checkReleaseBuilds false


### PR DESCRIPTION
From https://developer.android.com/google/play/requirements/target-sdk

> Starting August 31 2025:
>
> New apps and app updates must target Android 15 (API level 35) or higher to be submitted to Google Play;
>
> Existing apps must target Android 14 (API level 34) or higher to remain available to new users on devices running Android OS higher than your app's target API level. 


See extended commit message for more description

