### PR TITLE
Compile Android .so's with 16kb page sizes

### DIFF
--- a/android/build.gradle.nix
+++ b/android/build.gradle.nix
@@ -70,7 +70,7 @@ android {
     defaultConfig {
         applicationId "${applicationId}"
         minSdkVersion 21
-        targetSdkVersion 34
+        targetSdkVersion 35
         versionCode ${version.code}
         versionName "${version.name}"
         multiDexEnabled false

--- a/android/impl.nix
+++ b/android/impl.nix
@@ -3,19 +3,19 @@ let overrideAndroidCabal = package: overrideCabal package (drv: {
   # -Wl,--unresolved-symbols=ignore-in-object-files
   preConfigure = (drv.preConfigure or "") + ''
         export NIX_CFLAGS_LINK="-no-pie -v"
-        sed -i 's%^executable *\(.*\)$%executable lib\1.so\n    cc-options: -no-pie -shared -fPIC\n    ld-options: -no-pie -shared -Wl,--gc-sections,--version-script=${./haskellActivity.version},-u,Java_systems_obsidian_HaskellActivity_haskellStartMain,-u,hs_main\n    ghc-options: -fPIC -shared -no-pie -threaded -no-hs-main -lHSrts_thr -lffi -lm -llog%i' *.cabal
+        sed -i 's%^executable *\(.*\)$%executable lib\1.so\n    cc-options: -no-pie -shared -fPIC\n    ld-options: -no-pie -shared -Wl,--gc-sections,--version-script=${./haskellActivity.version},-u,Java_systems_obsidian_HaskellActivity_haskellStartMain,-u,hs_main\n    ghc-options: -fPIC -shared -no-pie -optl=-z -optl=max-page-size=16384 -optl=-z -optl=common-page-size=16384 -threaded -no-hs-main -lHSrts_thr -lffi -lm -llog%i' *.cabal
       '';
       # -no-hs-main
       configureFlags = (drv.configureFlags or []) ++ [
         "--enable-shared"
       ];
       });
-    /*  
+    /*
     overrideAndroidCabal = package: overrideCabal package (drv: {
       preConfigure = ''
         export NIX_CFLAGS_COMPILE=""
         export NIX_CFLAGS_LINK="-v -no-pie"
-      '';    
+      '';
       });
     */
     androidenv = nixpkgs.androidenv;

--- a/default.nix
+++ b/default.nix
@@ -174,7 +174,10 @@ let iosSupport = system == "x86_64-darwin";
             configureFlags = [ "--disable-shared" "--enable-static" ];
           });
 
-          libffi = if (self.stdenv.hostPlatform.useAndroidPrebuilt or false) then super.libffi_3_3 else super.libffi;
+          libffi = (if (self.stdenv.hostPlatform.useAndroidPrebuilt or false) then super.libffi_3_3 else super.libffi)
+            .overrideAttrs (old: {
+              ${if self.stdenv.hostPlatform.isAndroid then "LDFLAGS" else null} = "-Wl,-z,max-page-size=16384";
+            });
         })
       ] ++ nixpkgsOverlays;
       config = config // {


### PR DESCRIPTION
Fix for 

https://github.com/obsidiansystems/obelisk/issues/1133

Solution/changes: 

- ghc-options: add linker page size through optl=
-  targetSdkVersion == 35
-  libffi override 

